### PR TITLE
feat: AI-decides child count, editable prompts, task modal, mobile responsiveness

### DIFF
--- a/src/components/SettingsPanel.vue
+++ b/src/components/SettingsPanel.vue
@@ -14,6 +14,7 @@
           <button :class="{ active: tab === 'general' }" @click="tab = 'general'">General</button>
           <button :class="{ active: tab === 'save' }" @click="tab = 'save'">Save</button>
           <button :class="{ active: tab === 'api' }" @click="tab = 'api'">API Keys</button>
+          <button :class="{ active: tab === 'prompts' }" @click="tab = 'prompts'">Prompts</button>
         </aside>
 
         <main class="section">
@@ -86,6 +87,35 @@
 
             <button class="add" @click="settings.addProvider">+ Add custom provider</button>
             <p class="hint">Keys are stored only in this browser localStorage. This is fine for local personal use, but not for a public hosted app.</p>
+          </div>
+
+          <div v-if="tab === 'prompts'" class="api-section">
+            <label>
+              Active divide prompt
+              <select :value="settings.settings.prompts.selectedDividePromptId" @change="settings.selectDividePrompt($event.target.value)">
+                <option v-for="prompt in settings.settings.prompts.dividePrompts" :key="prompt.id" :value="prompt.id">
+                  {{ prompt.name }}
+                </option>
+              </select>
+            </label>
+
+            <div class="provider-card" v-for="prompt in settings.settings.prompts.dividePrompts" :key="prompt.id">
+              <div class="provider-head">
+                <strong>{{ prompt.name }}</strong>
+                <button class="small danger" @click="settings.removeDividePrompt(prompt.id)">Remove</button>
+              </div>
+              <label>
+                Name
+                <input :value="prompt.name" @input="settings.updateDividePrompt(prompt.id, { name: $event.target.value })" />
+              </label>
+              <label>
+                System prompt
+                <textarea class="prompt-textarea" rows="6" :value="prompt.content" @input="settings.updateDividePrompt(prompt.id, { content: $event.target.value })" />
+              </label>
+            </div>
+
+            <button class="add" @click="settings.addDividePrompt">+ Add custom prompt</button>
+            <p class="hint">The active prompt is used when the AI divides a task into child tasks. Customize prompts to match your domain and preferred task-splitting logic.</p>
           </div>
         </main>
       </div>
@@ -216,6 +246,19 @@ select {
   border-radius: 7px;
   background: var(--field);
   font-size: 13px;
+}
+.prompt-textarea {
+  width: 100%;
+  min-height: 100px;
+  border: 0;
+  border-radius: 7px;
+  padding: 10px 11px;
+  background: var(--field);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 13px;
+  resize: vertical;
+  line-height: 1.5;
 }
 @media (max-width: 760px) {
   .content { grid-template-columns: 1fr; }

--- a/src/components/StickyNode.vue
+++ b/src/components/StickyNode.vue
@@ -24,6 +24,7 @@
       <button class="icon-button nodrag" :title="data.collapsed ? 'Expand' : 'Collapse'" @click="store.toggleCollapse(id)">
         {{ data.collapsed ? '+' : '-' }}
       </button>
+      <button class="expand-btn nodrag" title="Open in modal" @click="openModal">↔</button>
     </header>
 
     <textarea
@@ -90,14 +91,15 @@
     <p v-if="data.systemMessage" class="system-message">{{ data.systemMessage }}</p>
 
     <footer class="actions">
-      <label class="child-count nodrag">
+      <label class="child-count nodrag" title="Leave empty for AI to decide">
         Children
         <input
           type="number"
           min="1"
           max="12"
           :value="data.childCount"
-          @input="update({ childCount: Number($event.target.value) })"
+          :placeholder="data.childCount == null ? 'auto' : ''"
+          @input="onChildCountInput"
         />
       </label>
       <button class="nodrag" :disabled="busy" @click="store.quickAddChild(id)">+ Child</button>
@@ -146,6 +148,8 @@ const props = defineProps({
   data: { type: Object, required: true },
 })
 
+const emit = defineEmits(['open-modal'])
+
 const store = useTreeStore()
 const newTag = ref('')
 const busy = computed(() => store.loadingNodeIds.includes(props.id))
@@ -185,6 +189,15 @@ function completeRelation() {
   store.completeRelation(props.id, label.trim())
 }
 
+function onChildCountInput(event) {
+  const value = event.target.value
+  if (value === '' || value === null) {
+    store.updateNodeData(props.id, { childCount: null })
+  } else {
+    store.updateNodeData(props.id, { childCount: Number(value) })
+  }
+}
+
 function onResizeMove(event) {
   if (!resizeStart) return
 
@@ -209,6 +222,10 @@ function startResize(event) {
   }
   window.addEventListener('pointermove', onResizeMove)
   window.addEventListener('pointerup', stopResize)
+}
+
+function openModal() {
+  emit('open-modal', props.id)
 }
 
 onBeforeUnmount(stopResize)
@@ -250,9 +267,29 @@ onBeforeUnmount(stopResize)
 
 .node-header {
   display: grid;
-  grid-template-columns: 10px 1fr 28px;
+  grid-template-columns: 10px 1fr 28px 28px;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
+}
+
+.expand-btn {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 14px;
+  opacity: 0.45;
+  transition: opacity 140ms ease, background 140ms ease;
+}
+
+.expand-btn:hover {
+  opacity: 1;
+  background: var(--field);
 }
 
 .status-dot {

--- a/src/components/TaskModal.vue
+++ b/src/components/TaskModal.vue
@@ -1,0 +1,420 @@
+<template>
+  <Teleport to="body">
+    <div class="modal-overlay" @click.self="close">
+      <section class="modal-panel">
+        <header class="modal-header">
+          <input
+            class="modal-title"
+            :value="node.data.title"
+            placeholder="Task title"
+            @input="update({ title: $event.target.value })"
+          />
+          <button class="icon-btn" @click="close">×</button>
+        </header>
+
+        <div class="modal-body">
+          <div class="field-group">
+            <label>Description</label>
+            <textarea
+              class="modal-textarea"
+              :value="node.data.content"
+              placeholder="Describe the task..."
+              @input="update({ content: $event.target.value })"
+            />
+          </div>
+
+          <div class="field-row">
+            <div class="field-group">
+              <label>Status</label>
+              <select
+                class="modal-select"
+                :value="node.data.taskStatus"
+                @change="update({ taskStatus: $event.target.value })"
+              >
+                <option v-for="status in store.statusOptions" :key="status.id" :value="status.id">
+                  {{ status.label }}
+                </option>
+              </select>
+            </div>
+            <div class="field-group">
+              <label>Progress</label>
+              <div class="progress-display">
+                <div class="progress-bar">
+                  <span :style="{ width: `${node.data.progress}%` }" />
+                </div>
+                <strong>{{ node.data.progress }}%</strong>
+              </div>
+            </div>
+          </div>
+
+          <div class="field-group">
+            <label>Tags</label>
+            <div class="tags-row">
+              <span
+                v-for="tag in node.data.tags"
+                :key="tag"
+                class="modal-tag"
+                :style="tagStyle(tag)"
+              >
+                {{ tag }}
+                <button class="tag-remove" @click="store.removeTag(node.id, tag)">x</button>
+              </span>
+              <input
+                v-model="newTag"
+                class="tag-input"
+                placeholder="+ tag"
+                @keydown.enter.prevent="commitTag"
+                @blur="commitTag"
+              />
+            </div>
+          </div>
+
+          <div class="field-group">
+            <label>Notes</label>
+            <textarea
+              class="modal-textarea"
+              :value="node.data.notes"
+              placeholder="Markdown notes..."
+              @input="update({ notes: $event.target.value })"
+            />
+            <div v-if="node.data.notes" class="markdown-preview" v-html="notesHtml" />
+          </div>
+
+          <div v-if="node.data.systemMessage" class="system-message">
+            {{ node.data.systemMessage }}
+          </div>
+        </div>
+
+        <footer class="modal-footer">
+          <label class="child-count" title="Leave empty for AI to decide">
+            Children
+            <input
+              type="number"
+              min="1"
+              max="12"
+              :value="node.data.childCount"
+              :placeholder="node.data.childCount == null ? 'auto' : ''"
+              @input="onChildCountInput"
+            />
+          </label>
+          <button :disabled="busy" @click="store.quickAddChild(node.id)">+ Child</button>
+          <button :disabled="busy" @click="store.aiDivide(node.id)">AI Divide</button>
+          <button :disabled="busy" class="secondary" @click="store.aiReformulate(node.id)">Refine</button>
+          <button :disabled="busy" class="secondary" @click="store.duplicateNode(node.id)">Duplicate</button>
+          <button v-if="node.id !== 'root'" class="danger" @click="deleteNode">Delete</button>
+        </footer>
+      </section>
+    </div>
+  </Teleport>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue'
+import { useTreeStore } from '../stores/treeStore'
+import { getTagColor } from '../utils/treeUtils'
+import { renderMarkdown } from '../utils/markdown'
+
+const props = defineProps({
+  nodeId: { type: String, required: true },
+})
+
+const emit = defineEmits(['close'])
+
+const store = useTreeStore()
+const newTag = ref('')
+
+const node = computed(() => store.nodeById.get(props.nodeId))
+const busy = computed(() => store.loadingNodeIds.includes(props.nodeId))
+const notesHtml = computed(() => renderMarkdown(node.value?.data?.notes))
+
+function update(patch) {
+  store.updateNodeData(props.nodeId, patch)
+}
+
+function close() {
+  emit('close')
+}
+
+function tagStyle(tag) {
+  const color = getTagColor(tag)
+  return { '--tag-bg': color.background, '--tag-text': color.color }
+}
+
+function commitTag() {
+  const value = newTag.value.trim()
+  if (!value) return
+  store.addTag(props.nodeId, value)
+  newTag.value = ''
+}
+
+function onChildCountInput(event) {
+  const value = event.target.value
+  if (value === '' || value === null) {
+    store.updateNodeData(props.nodeId, { childCount: null })
+  } else {
+    store.updateNodeData(props.nodeId, { childCount: Number(value) })
+  }
+}
+
+function deleteNode() {
+  store.deleteNode(props.nodeId)
+  close()
+}
+</script>
+
+<style scoped>
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  background: rgba(0, 0, 0, 0.42);
+}
+
+.modal-panel {
+  width: min(680px, 100%);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  background: var(--surface);
+  box-shadow: var(--shadow-strong);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--panel-border);
+}
+
+.modal-title {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 18px;
+  font-weight: 760;
+}
+
+.icon-btn {
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 7px;
+  background: var(--button);
+  color: var(--button-text);
+  font-size: 22px;
+  cursor: pointer;
+}
+
+.modal-body {
+  flex: 1;
+  overflow: auto;
+  display: grid;
+  gap: 16px;
+  padding: 18px;
+}
+
+.field-group {
+  display: grid;
+  gap: 6px;
+}
+
+.field-group label {
+  font-size: 12px;
+  font-weight: 800;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.field-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.modal-textarea {
+  width: 100%;
+  min-height: 80px;
+  border: 0;
+  border-radius: 7px;
+  padding: 10px 11px;
+  background: var(--field);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.modal-select {
+  width: 100%;
+  border: 0;
+  border-radius: 7px;
+  padding: 10px 11px;
+  background: var(--field);
+  color: var(--text);
+}
+
+.progress-display {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.progress-bar {
+  flex: 1;
+  height: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--field);
+}
+
+.progress-bar span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent);
+  transition: width 180ms ease;
+}
+
+.tags-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.modal-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: var(--tag-bg);
+  color: var(--tag-text);
+  font-size: 12px;
+  font-weight: 760;
+}
+
+.tag-remove {
+  padding: 0;
+  width: 16px;
+  height: 16px;
+  display: grid;
+  place-items: center;
+  border: 0;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--tag-text) 12%, transparent);
+  color: var(--tag-text);
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.tag-input {
+  width: 80px;
+  min-width: 60px;
+  border: 0;
+  outline: none;
+  padding: 4px 2px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.markdown-preview {
+  padding: 10px;
+  border-radius: 7px;
+  background: var(--preview);
+  color: var(--muted-strong);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.system-message {
+  padding: 8px 10px;
+  border-radius: 7px;
+  background: var(--field);
+  color: var(--danger);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.modal-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 18px;
+  border-top: 1px solid var(--panel-border);
+  flex-wrap: wrap;
+}
+
+.modal-footer button {
+  border: 0;
+  border-radius: 7px;
+  padding: 8px 12px;
+  background: var(--button);
+  color: var(--button-text);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 760;
+  white-space: nowrap;
+}
+
+.modal-footer button:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
+.modal-footer .secondary {
+  background: var(--button-secondary);
+}
+
+.modal-footer .danger {
+  background: var(--danger);
+}
+
+.child-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 720;
+}
+
+.child-count input {
+  width: 42px;
+  padding: 6px 7px;
+  border: 0;
+  border-radius: 7px;
+  background: var(--field);
+  color: var(--text);
+}
+
+@media (max-width: 600px) {
+  .field-row {
+    grid-template-columns: 1fr;
+  }
+  .modal-panel {
+    width: 100%;
+    max-height: 100vh;
+    border-radius: 0;
+  }
+  .modal-overlay {
+    padding: 0;
+  }
+}
+</style>

--- a/src/services/aiService.js
+++ b/src/services/aiService.js
@@ -43,17 +43,21 @@ async function callChatCompletion({ provider, messages, temperature = 0.35 }) {
   return content.trim()
 }
 
-export async function divideTask({ provider, node, ancestors, count }) {
+export async function divideTask({ provider, node, ancestors, count, systemPrompt }) {
+  const countInstruction = count != null
+    ? `Divide this task into exactly ${count} focused child tasks.`
+    : 'Divide this task into a reasonable number of child tasks (between 1 and 12) based on the complexity of the work. Decide the count yourself.'
+
   const content = await callChatCompletion({
     provider,
     messages: [
       {
         role: 'system',
-        content: 'You are a senior software architect. Break software work into clear implementation tasks for Laravel, Vue, tests, services, controllers, models, or functions. Return JSON only.',
+        content: systemPrompt || 'You are a senior software architect. Break software work into clear implementation tasks for Laravel, Vue, tests, services, controllers, models, or functions. Return JSON only.',
       },
       {
         role: 'user',
-        content: `Ancestor context:\n${buildContextLine(ancestors)}\n\nCurrent task title: ${node.data.title}\nCurrent task content: ${node.data.content || ''}\n\nDivide this task into ${count} focused child tasks. Return a JSON array only. Each item must be an object with this shape: {"title":"short title","content":"short implementation expectation"}.`,
+        content: `Ancestor context:\n${buildContextLine(ancestors)}\n\nCurrent task title: ${node.data.title}\nCurrent task content: ${node.data.content || ''}\n\n${countInstruction}\nReturn a JSON array only. Each item must be an object with this shape: {"title":"short title","content":"short implementation expectation"}.`,
       },
     ],
   })

--- a/src/services/settingsService.js
+++ b/src/services/settingsService.js
@@ -1,5 +1,28 @@
 const SETTINGS_KEY = 'mushajjir-settings-v1'
 
+export const DEFAULT_DIVIDE_PROMPTS = [
+  {
+    id: 'coding-default',
+    name: 'Coding — Default',
+    content: 'You are a senior software architect. Break software work into clear implementation tasks for Laravel, Vue, tests, services, controllers, models, or functions. Return JSON only.',
+  },
+  {
+    id: 'coding-detailed',
+    name: 'Coding — Detailed specs',
+    content: 'You are a senior software architect. Break the software work into detailed atomic implementation tasks. Each task must include specific file names, method signatures, and test expectations when relevant. Target Laravel + Vue + Inertia stack. Return JSON only.',
+  },
+  {
+    id: 'coding-tdd',
+    name: 'Coding — TDD first',
+    content: 'You are a senior software architect following Test-Driven Development. Break the work into tasks where tests are defined first (red), then implementation (green), then refactoring. Return JSON only.',
+  },
+  {
+    id: 'coding-micro',
+    name: 'Coding — Micro tasks',
+    content: 'You are a senior software architect. Break the work into very small, granular tasks suitable for LLM coding agents with limited context. Each task should be completable in a single code edit session (under 50 lines of code). Prefer more, smaller tasks over fewer larger ones. Return JSON only.',
+  },
+]
+
 export const DEFAULT_PROVIDERS = [
   {
     id: 'openrouter',
@@ -38,6 +61,10 @@ export const DEFAULT_SETTINGS = {
     selectedProviderId: 'openrouter',
     providers: DEFAULT_PROVIDERS,
   },
+  prompts: {
+    selectedDividePromptId: 'coding-default',
+    dividePrompts: DEFAULT_DIVIDE_PROMPTS,
+  },
 }
 
 function mergeSettings(saved) {
@@ -60,7 +87,26 @@ function mergeSettings(saved) {
       selectedProviderId: saved.ai?.selectedProviderId || DEFAULT_SETTINGS.ai.selectedProviderId,
       providers: [...providers, ...customProviders],
     },
+    prompts: {
+      selectedDividePromptId: saved.prompts?.selectedDividePromptId || DEFAULT_SETTINGS.prompts.selectedDividePromptId,
+      dividePrompts: mergeDividePrompts(saved.prompts?.dividePrompts),
+    },
   }
+}
+
+function mergeDividePrompts(savedPrompts) {
+  if (!Array.isArray(savedPrompts) || !savedPrompts.length) return structuredClone(DEFAULT_DIVIDE_PROMPTS)
+
+  const defaults = DEFAULT_DIVIDE_PROMPTS.map((prompt) => ({
+    ...prompt,
+    ...(savedPrompts.find((item) => item.id === prompt.id) || {}),
+  }))
+
+  const customPrompts = savedPrompts.filter(
+    (prompt) => !DEFAULT_DIVIDE_PROMPTS.some((item) => item.id === prompt.id),
+  )
+
+  return [...defaults, ...customPrompts]
 }
 
 export function loadSettings() {

--- a/src/stores/settingsStore.js
+++ b/src/stores/settingsStore.js
@@ -58,9 +58,44 @@ export const useSettingsStore = defineStore('settings', () => {
     }
   }
 
+  const activeDividePrompt = computed(() => (
+    settings.value.prompts.dividePrompts.find((prompt) => prompt.id === settings.value.prompts.selectedDividePromptId)
+    || settings.value.prompts.dividePrompts[0]
+    || null
+  ))
+
+  function selectDividePrompt(id) {
+    settings.value.prompts.selectedDividePromptId = id
+  }
+
+  function updateDividePrompt(id, patch) {
+    settings.value.prompts.dividePrompts = settings.value.prompts.dividePrompts.map((prompt) => (
+      prompt.id === id ? { ...prompt, ...patch } : prompt
+    ))
+  }
+
+  function addDividePrompt() {
+    const id = `custom-prompt-${Date.now()}`
+    settings.value.prompts.dividePrompts.push({
+      id,
+      name: 'Custom prompt',
+      content: 'You are a senior software architect. Break the work into clear tasks. Return JSON only.',
+    })
+    settings.value.prompts.selectedDividePromptId = id
+  }
+
+  function removeDividePrompt(id) {
+    if (settings.value.prompts.dividePrompts.length <= 1) return
+    settings.value.prompts.dividePrompts = settings.value.prompts.dividePrompts.filter((prompt) => prompt.id !== id)
+    if (settings.value.prompts.selectedDividePromptId === id) {
+      settings.value.prompts.selectedDividePromptId = settings.value.prompts.dividePrompts[0]?.id || ''
+    }
+  }
+
   return {
     settings,
     selectedProvider,
+    activeDividePrompt,
     updateGeneral,
     updateSave,
     toggleTheme,
@@ -68,5 +103,9 @@ export const useSettingsStore = defineStore('settings', () => {
     updateProvider,
     addProvider,
     removeProvider,
+    selectDividePrompt,
+    updateDividePrompt,
+    addDividePrompt,
+    removeDividePrompt,
   }
 })

--- a/src/stores/treeStore.js
+++ b/src/stores/treeStore.js
@@ -52,7 +52,6 @@ function defaultTree() {
       title: 'Implement user management',
       content: 'Break this feature into backend, frontend, and verification tasks that an AI coding agent can execute safely.',
       tags: ['ai-generated'],
-      childCount: 4,
       taskStatus: 'in-progress',
       width: 340,
     },
@@ -404,7 +403,6 @@ export const useTreeStore = defineStore('tree', () => {
           content: payload.content || payload.description || '',
           tags: Array.isArray(payload.tags) ? payload.tags : [],
           taskStatus: payload.taskStatus || 'todo',
-          childCount: 4,
         },
       })
     })
@@ -581,15 +579,18 @@ export const useTreeStore = defineStore('tree', () => {
     if (!parent) return
 
     const settingsStore = useSettingsStore()
-    const count = clamp(Number(parent.data.childCount || 4), 3, 8)
+    const raw = parent.data.childCount
+    const count = raw != null ? clamp(Number(raw), 3, 8) : null
 
     try {
       setNodeBusy(parentId, true)
+      const activePrompt = settingsStore.activeDividePrompt
       const tasks = await divideTask({
         provider: settingsStore.selectedProvider,
         node: parent,
         ancestors: ancestorNodes(parentId).map((node) => node.data),
         count,
+        systemPrompt: activePrompt?.content || undefined,
       })
       createChildNodes(parentId, tasks)
       updateNodeData(parentId, { systemMessage: '' })

--- a/src/style.css
+++ b/src/style.css
@@ -141,3 +141,82 @@ button:hover:not(:disabled) {
 .vue-flow__minimap-mask {
   fill: color-mix(in srgb, var(--accent) 12%, transparent);
 }
+
+/* ── Mobile responsiveness ── */
+
+@media (max-width: 700px) {
+  body {
+    overflow: auto;
+  }
+
+  #app {
+    height: auto;
+    min-height: 100dvh;
+  }
+
+  .vue-flow__minimap {
+    display: none !important;
+  }
+
+  .vue-flow__controls {
+    scale: 0.72;
+    transform-origin: bottom left;
+  }
+
+  .vue-flow__node {
+    transform-origin: top left;
+  }
+
+  .vue-flow__node .node-header {
+    grid-template-columns: 8px 1fr 24px 24px !important;
+    gap: 4px !important;
+  }
+
+  .vue-flow__node .title {
+    font-size: 13px !important;
+  }
+
+  .vue-flow__node .content {
+    min-height: 48px !important;
+    font-size: 12px !important;
+  }
+
+  .vue-flow__node .actions {
+    gap: 4px !important;
+  }
+
+  .vue-flow__node .actions button {
+    padding: 5px 7px !important;
+    font-size: 11px !important;
+  }
+
+  .vue-flow__node .child-count {
+    font-size: 11px !important;
+  }
+
+  .vue-flow__node .child-count input {
+    width: 34px !important;
+    padding: 4px !important;
+  }
+
+  .vue-flow__node .status-select {
+    padding: 4px 6px !important;
+    font-size: 11px !important;
+  }
+
+  .vue-flow__node .tag {
+    font-size: 10px !important;
+    padding: 2px 5px !important;
+  }
+
+  .vue-flow__node .tag-input {
+    width: 48px !important;
+    font-size: 11px !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .vue-flow__controls {
+    scale: 0.58;
+  }
+}

--- a/src/utils/treeUtils.js
+++ b/src/utils/treeUtils.js
@@ -53,7 +53,7 @@ export function normalizeNodeData(data = {}) {
     notes: data.notes || '',
     notesOpen: Boolean(data.notesOpen),
     tags: Array.isArray(data.tags) ? data.tags.map(cleanTag).filter(Boolean) : [],
-    childCount: clamp(Number(data.childCount || 4), 1, 12),
+    childCount: data.childCount != null ? clamp(Number(data.childCount), 1, 12) : null,
     parentId: data.parentId ?? null,
     taskStatus: data.taskStatus || (oldStatusIsTaskState ? oldStatus : 'todo'),
     systemMessage: data.systemMessage || (!oldStatusIsTaskState ? oldStatus : ''),

--- a/src/views/CanvasView.vue
+++ b/src/views/CanvasView.vue
@@ -7,6 +7,7 @@
     />
     <OutlinePanel v-if="showOutline" />
     <SettingsPanel v-if="showSettings" @close="showSettings = false" />
+    <TaskModal v-if="modalNodeId" :node-id="modalNodeId" @close="modalNodeId = null" />
 
     <VueFlow
       :nodes="store.flowNodes"
@@ -21,6 +22,7 @@
       @node-click="onNodeClick"
       @pane-click="onPaneClick"
       @node-drag-stop="onNodeDragStop"
+      @node-double-click="onNodeDoubleClick"
     >
       <Background :pattern-color="backgroundColor" :gap="24" />
       <Controls />
@@ -39,6 +41,7 @@ import Toolbar from '../components/Toolbar.vue'
 import SettingsPanel from '../components/SettingsPanel.vue'
 import OutlinePanel from '../components/OutlinePanel.vue'
 import StickyNode from '../components/StickyNode.vue'
+import TaskModal from '../components/TaskModal.vue'
 import { useTreeStore } from '../stores/treeStore'
 import { useSettingsStore } from '../stores/settingsStore'
 
@@ -46,6 +49,7 @@ const store = useTreeStore()
 const settings = useSettingsStore()
 const showSettings = ref(false)
 const showOutline = ref(true)
+const modalNodeId = ref(null)
 const nodeTypes = {
   task: markRaw(StickyNode),
   sticky: markRaw(StickyNode),
@@ -73,6 +77,10 @@ function onNodeClick({ node }) {
 
 function onPaneClick() {
   store.cancelRelation()
+}
+
+function onNodeDoubleClick({ node }) {
+  modalNodeId.value = node.id
 }
 
 function onNodeDragStop({ node }) {


### PR DESCRIPTION

## Summary

Four improvements to Mushajjir:

### 1. AI decides number of child notes
- `childCount` defaults to `null` (empty) instead of `4`
- When empty, the AI decides how many child tasks to create based on complexity (1-12)
- User can still set a fixed number if desired; the input shows "auto" placeholder when empty

### 2. Editable prompt list
- Added 4 default coding prompts: Default, Detailed specs, TDD first, Micro tasks
- New **Prompts** tab in Settings panel where users can edit, add, and remove prompts
- The active prompt is used as the system message when AI divides tasks
- Ready for future non-coding task types

### 3. Task modal
- New `TaskModal.vue` component for viewing/editing tasks in a full dialog
- Triggered by double-clicking a node or clicking the `↔` button in the node header
- Shows all fields: title, content, status, progress, tags, notes with markdown preview
- Includes all actions: add child, AI divide, refine, duplicate, delete

### 4. Mobile responsiveness
- CSS media queries for screens ≤700px and ≤480px
- Hides minimap, scales controls, shrinks node elements
- Modal becomes full-screen on mobile
- Body scrolls naturally instead of fixed overflow

## Files changed
- `src/components/TaskModal.vue` (new)
- `src/components/SettingsPanel.vue` (prompts tab)
- `src/components/StickyNode.vue` (expand button, child count input)
- `src/services/aiService.js` (flexible count + system prompt)
- `src/services/settingsService.js` (default prompts)
- `src/stores/settingsStore.js` (prompt management)
- `src/stores/treeStore.js` (null childCount handling)
- `src/style.css` (mobile responsiveness)
- `src/utils/treeUtils.js` (null childCount default)
- `src/views/CanvasView.vue` (modal integration, double-click)
